### PR TITLE
Fix errors if the directory have spaces on Windows.

### DIFF
--- a/bin/win64/decode.cmd
+++ b/bin/win64/decode.cmd
@@ -1,7 +1,7 @@
 @echo off
 
-SET thisDir=%~dp0
-SET encodeFile=%1
+SET "thisDir=%~dp0"
+SET "encodeFile=%1"
 
 if [%1]==[] (
 	echo Please provide as parameter the movie file you wish to decode.
@@ -11,7 +11,7 @@ if [%1]==[] (
 
 echo Converting video to frames
 mkdir "%thisDir%qr-frames"
-"%thisDir%ffmpeg\bin\ffmpeg.exe" -i "%encodeFile%" "%thisDir%qr-frames\%%015d.png"
+"%thisDir%ffmpeg\bin\ffmpeg.exe" -i %encodeFile% "%thisDir%qr-frames\%%015d.png"
 echo.
 
 echo Converting frames to file

--- a/bin/win64/encode.cmd
+++ b/bin/win64/encode.cmd
@@ -1,7 +1,7 @@
 @echo off
 
-SET thisDir=%~dp0
-SET encodeFile=%1
+SET "thisDir=%~dp0"
+SET "encodeFile=%1"
 
 if [%1]==[] (
 	echo Please provide as parameter the file you wish to encode.
@@ -10,7 +10,7 @@ if [%1]==[] (
 )
 
 echo Converting file to frames
-"%thisDir%file2qr\cli.exe" -encode -encode-file="%encodeFile%" -encode-folder-destination="%thisDir%qr-frames"
+"%thisDir%file2qr\cli.exe" -encode -encode-file=%encodeFile% -encode-folder-destination="%thisDir%qr-frames"
 echo.
 
 echo Converting frames to video


### PR DESCRIPTION
I simply tested on Windows and there were errors with paths having spaces.
Adding the quotes solved it.